### PR TITLE
docs: AI 도구 호환성 목록 갱신 (Gemini CLI → Antigravity, Cursor 제외) (#19)

### DIFF
--- a/.ai/90_issues/active/issue-0019/issue-0019-plan.md
+++ b/.ai/90_issues/active/issue-0019/issue-0019-plan.md
@@ -1,0 +1,51 @@
+# Issue #19 실행계획 AI 도구 호환성 목록 갱신 (Gemini CLI → Antigravity, Cursor 제외)
+
+> 스펙: [issue-0019-spec.md](./issue-0019-spec.md)
+
+---
+
+## Tasks
+
+> AI가 순서대로 실행할 작업 단위를 정의합니다.
+> 각 작업은 독립적으로 검증 가능해야 합니다.
+
+### Task 1: README.md 갱신
+
+- [x] 완료
+- **목표**: README의 도구 나열 문장에서 Gemini CLI → Antigravity, Cursor 제거
+- **작업 내용**:
+  1. 도구 나열 문장에서 "Gemini CLI"를 "Antigravity"로 교체
+  2. 동일 문장에서 "Cursor" 제거 후 어순·구두점 정리
+- **완료 기준**: README.md에 "Gemini CLI"·"Cursor" 잔여 없음, 문장이 자연스러움
+
+---
+
+### Task 2: .ai/AI-CONTEXT.md 갱신
+
+- [x] 완료
+- **목표**: AI-CONTEXT의 `domain` 행과 본문에서 Gemini CLI → Antigravity, Cursor 제거
+- **작업 내용**:
+  1. `domain` 행의 "Cursor·Gemini CLI" → "Antigravity"로 정리 (Cursor 제거)
+  2. "프로젝트 목적" 본문의 "Cursor, Gemini CLI" → "Antigravity"로 정리 (Cursor 제거)
+- **완료 기준**: AI-CONTEXT.md에 "Gemini CLI"·"Cursor" 잔여 없음, 문장이 자연스러움
+
+---
+
+### Task 3: context-save/SKILL.md 갱신
+
+- [x] 완료
+- **목표**: SKILL.md의 Gemini CLI 언급(2곳)을 Antigravity로 교체
+- **작업 내용**:
+  1. 8행 도구 나열에서 "Gemini CLI" → "Antigravity"
+  2. 176행 공통 포맷 설명에서 "Gemini CLI" → "Antigravity"
+- **완료 기준**: context-save/SKILL.md에 "Gemini CLI" 잔여 없음
+
+---
+
+### Task 4: 잔여 언급 검증
+
+- [x] 완료
+- **목표**: archive를 제외한 전체에서 변경 누락이 없는지 확인
+- **작업 내용**:
+  1. `grep -rn "Gemini CLI\|Cursor" --include="*.md"`로 archive 외 잔여 확인
+- **완료 기준**: archive 외 잔여 언급 0건

--- a/.ai/90_issues/active/issue-0019/issue-0019-spec.md
+++ b/.ai/90_issues/active/issue-0019/issue-0019-spec.md
@@ -1,0 +1,40 @@
+# Issue #19 스펙 AI 도구 호환성 목록 갱신 (Gemini CLI → Antigravity, Cursor 제외)
+
+## 목표 (Goal)
+
+문서에 나열된 호환 AI 도구 목록에서 "Gemini CLI"를 "Antigravity"로 바꾸고 "Cursor"를 제거한다.
+
+---
+
+## 범위 (Scope)
+
+**포함 (In)**
+
+- `README.md` — 도구 나열 문장의 "Gemini CLI" → "Antigravity", "Cursor" 제거
+- `.ai/AI-CONTEXT.md` — `domain` 행 및 본문의 "Gemini CLI" → "Antigravity", "Cursor" 제거
+- `context-save/SKILL.md` — "Gemini CLI" 언급(2곳) → "Antigravity"
+- 도구 나열 문장의 어순·구두점 자연스럽게 정리
+
+**비포함 (Out)**
+
+- `.ai/90_issues/archive/` 하위 과거 이슈 문서 (이력 보존, 수정하지 않음)
+- 도구 목록과 무관한 본문 내용 변경
+
+---
+
+## 완료의 정의 (Definition of Done)
+
+- [ ] `README.md`, `.ai/AI-CONTEXT.md`, `context-save/SKILL.md`에서 "Gemini CLI"가 "Antigravity"로 모두 교체됨
+- [ ] `README.md`, `.ai/AI-CONTEXT.md`에서 "Cursor" 언급이 제거됨
+- [ ] 도구 나열 문장의 어순·구두점이 자연스럽게 정리됨
+- [ ] archive를 제외한 전체 `*.md`에 "Gemini CLI"·"Cursor" 잔여 언급이 없음 (grep 확인)
+
+---
+
+## 연관 문서
+
+| 문서 | 역할 |
+|------|------|
+| `README.md` | 변경 대상 — 도구 호환성 나열 문장 |
+| `.ai/AI-CONTEXT.md` | 변경 대상 — `domain` 행 및 프로젝트 목적 본문 |
+| `context-save/SKILL.md` | 변경 대상 — Gemini CLI 언급 부분 |

--- a/.ai/90_issues/active/issue-0019/issue-0019-summary.md
+++ b/.ai/90_issues/active/issue-0019/issue-0019-summary.md
@@ -1,0 +1,41 @@
+# Issue #19 실행요약 AI 도구 호환성 목록 갱신 (Gemini CLI → Antigravity, Cursor 제외)
+
+> 스펙: [issue-0019-spec.md](./issue-0019-spec.md) | 계획: [issue-0019-plan.md](./issue-0019-plan.md)
+
+## 다음 작업
+
+> ✅ 모든 작업이 완료되었습니다.
+
+---
+
+## Task별 수행 결과
+
+### Task 1: README.md 갱신
+
+- **결과**: 완료
+- **수행 내용 요약**: 7행 도구 나열 문장에서 "Gemini CLI" → "Antigravity"로 교체하고 "Cursor"를 제거. 결과: "Claude Code, Codex, Antigravity, GitHub Copilot 등".
+- **특이 사항**: 없음
+
+---
+
+### Task 2: .ai/AI-CONTEXT.md 갱신
+
+- **결과**: 완료
+- **수행 내용 요약**: `domain` 행(15행)을 "Claude Code·Antigravity·Junie 등"으로, 프로젝트 목적 본문(25행)을 "Claude Code, Antigravity, Junie 등"으로 정리. 두 곳 모두 Gemini CLI → Antigravity 교체 및 Cursor 제거.
+- **특이 사항**: 없음
+
+---
+
+### Task 3: context-save/SKILL.md 갱신
+
+- **결과**: 완료
+- **수행 내용 요약**: 8행·176행의 "Gemini CLI" 2곳을 "Antigravity"로 교체. (이 파일에는 Cursor 언급 없음)
+- **특이 사항**: 없음
+
+---
+
+### Task 4: 잔여 언급 검증
+
+- **결과**: 완료
+- **수행 내용 요약**: `grep -rn "Gemini CLI\|Cursor" --include="*.md"`로 archive·현재 이슈 디렉토리를 제외한 전체를 확인 — 잔여 0건. Antigravity 반영도 대상 3개 파일에서 확인.
+- **특이 사항**: `.ai/90_issues/archive/` 하위 과거 이슈 문서는 이력 보존을 위해 변경하지 않음(스펙 비포함 항목).

--- a/.ai/AI-CONTEXT.md
+++ b/.ai/AI-CONTEXT.md
@@ -12,7 +12,7 @@
 
 | 항목 | 값 |
 |------|----|
-| domain | Claude Code·Cursor·Gemini CLI·Junie 등 다양한 AI 도구에서 호환되는 Agent Skills 모음 저장소 |
+| domain | Claude Code·Antigravity·Junie 등 다양한 AI 도구에서 호환되는 Agent Skills 모음 저장소 |
 | keywords | agent skills, agentskills, claude code, ai-workspace, ai 협업 가이드, skill 모음 |
 
 > `domain`/`keywords`는 단독/멀티 여부와 무관하게 에이전트 진입 단서로 유지한다. 상위 워크스페이스 안내도(`../.ai/AI-CONTEXT.md`) 존재 여부는 런타임에 자동 판정한다 (CoC).
@@ -22,7 +22,7 @@
 ## 프로젝트 목적
 
 개인적으로 사용하는 [Agent Skills](https://agentskills.io/)를 만들고 관리하는 저장소입니다.
-Agent Skills 오픈 포맷을 따르며, Claude Code, Cursor, Gemini CLI, Junie 등 다양한 AI 도구에서 호환됩니다.
+Agent Skills 오픈 포맷을 따르며, Claude Code, Antigravity, Junie 등 다양한 AI 도구에서 호환됩니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 개인적으로 사용할 [Agent Skills](https://agentskills.io/)를 모아두는 프로젝트입니다.
 
-Agent Skills는 특정 벤더에 종속되지 않는 오픈 포맷으로, Claude Code, Codex, Gemini CLI, GitHub Copilot, Cursor 등 다양한 AI 개발 도구에서 호환됩니다.
+Agent Skills는 특정 벤더에 종속되지 않는 오픈 포맷으로, Claude Code, Codex, Antigravity, GitHub Copilot 등 다양한 AI 개발 도구에서 호환됩니다.
 
 ## Skill 목록
 

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -5,7 +5,7 @@ description: 대화 중 중요한 맥락(배경, 결정, 미결 사항, 다음 �
 
 ## 개요
 
-현재 대화에서 오간 논의의 핵심을 **AI 에이전트 독립적인 마크다운 파일**로 `.ai/99_workspace/notes/`에 **임시 저장**하는 스킬입니다. 다음 세션의 에이전트(Claude Code, Codex, Gemini CLI, GitHub Copilot 등)가 파일만 읽고도 맥락을 이어갈 수 있도록 **대화 재현이 아닌 상태 스냅샷**을 기록합니다.
+현재 대화에서 오간 논의의 핵심을 **AI 에이전트 독립적인 마크다운 파일**로 `.ai/99_workspace/notes/`에 **임시 저장**하는 스킬입니다. 다음 세션의 에이전트(Claude Code, Codex, Antigravity, GitHub Copilot 등)가 파일만 읽고도 맥락을 이어갈 수 있도록 **대화 재현이 아닌 상태 스냅샷**을 기록합니다.
 
 `.ai/99_workspace/`는 임시 작업공간이며, 주 사용 흐름은 다음과 같습니다:
 
@@ -173,6 +173,6 @@ slug는 기본적으로 **대화 주제에서 자동 생성**합니다. 인자�
 
 ## 다른 AI 도구와의 호환성
 
-- 마크다운 + YAML 프론트매터는 Claude Code, Codex, Gemini CLI, GitHub Copilot 등 공통 포맷.
+- 마크다운 + YAML 프론트매터는 Claude Code, Codex, Antigravity, GitHub Copilot 등 공통 포맷.
 - 파일 하나가 자기 완결적이므로 도구를 바꿔도 그대로 읽힌다.
 - 도구별 세션 로그나 히스토리 파일에 의존하지 않는다.


### PR DESCRIPTION
## 이슈 목록
- #19 - AI 도구 호환성 목록 갱신 (Gemini CLI → Antigravity, Cursor 제외)

---

### Issue: #19 - AI 도구 호환성 목록 갱신 (Gemini CLI → Antigravity, Cursor 제외)

#### 1. 비즈니스 관점
* **목적 및 요약:** 저장소가 호환을 표방하는 AI 도구 목록을 최신 상태로 유지한다. "Gemini CLI"를 후속 명칭 "Antigravity"로 변경하고, 더 이상 호환 대상으로 두지 않는 "Cursor"를 목록에서 제외한다.
* **주요 변경 사항:**
  - 문서상 호환 도구 표기에서 Gemini CLI → Antigravity
  - Cursor를 호환 도구 목록에서 제외
* **참고사항:** 코드 동작 변경 없음 — 문서 표기 변경에 한정.

#### 2. 테크 관점
* **구현 요약:** 도구를 나열하는 문장을 텍스트 치환. AI-CONTEXT의 `domain` 행도 동일 기준으로 정리.
* **변경 파일:**
  - `README.md` — 도구 나열 문장 (1곳)
  - `.ai/AI-CONTEXT.md` — `domain` 행 + 프로젝트 목적 본문 (2곳)
  - `context-save/SKILL.md` — 도구 나열 (2곳, Cursor 언급 없음)
* **검증:** archive 제외 전체 `*.md`에서 "Gemini CLI"·"Cursor" 잔여 0건 확인 (grep).
* **참고사항:** 코드 호출 흐름 변경 없음(문서 변경). `.ai/90_issues/archive/` 과거 이슈 문서는 이력 보존을 위해 미변경.

---

## 문서 동기화 점검
- AI-CONTEXT의 `domain` 행을 이 PR에서 직접 갱신함. 단독 repo(상위 `../.ai/AI-CONTEXT.md` 부재)이므로 상위 워크스페이스 안내도 `Repos` 행 동기화는 불필요.
- `context-save/SKILL.md`는 본문만 변경했고 프론트매터 `description`은 미변경 → README/AI-CONTEXT 스킬 목록에 영향 없음.